### PR TITLE
Port to PHP8

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -150,7 +150,7 @@ function generate_stopwords_cache()
 	$d = dir(PUN_ROOT.'lang');
 	while (($entry = $d->read()) !== false)
 	{
-		if ($entry{0} == '.')
+		if ($entry[0] == '.')
 			continue;
 
 		if (is_dir(PUN_ROOT.'lang/'.$entry) && file_exists(PUN_ROOT.'lang/'.$entry.'/stopwords.txt'))

--- a/include/functions.php
+++ b/include/functions.php
@@ -1798,7 +1798,7 @@ function forum_list_styles()
 	$d = dir(PUN_ROOT.'style');
 	while (($entry = $d->read()) !== false)
 	{
-		if ($entry{0} == '.')
+		if ($entry[0] == '.')
 			continue;
 
 		if (substr($entry, -4) == '.css')
@@ -1822,7 +1822,7 @@ function forum_list_langs()
 	$d = dir(PUN_ROOT.'lang');
 	while (($entry = $d->read()) !== false)
 	{
-		if ($entry{0} == '.')
+		if ($entry[0] == '.')
 			continue;
 
 		if (is_dir(PUN_ROOT.'lang/'.$entry) && file_exists(PUN_ROOT.'lang/'.$entry.'/common.php'))
@@ -2026,7 +2026,7 @@ function url_valid($url)
 		return FALSE;	// Unrecognised URI scheme. Default to FALSE.
 	}
 	// Validate host name conforms to DNS "dot-separated-parts".
-	if ($m{'regname'}) // If host regname specified, check for DNS conformance.
+	if ($m['regname']) // If host regname specified, check for DNS conformance.
 	{
 		if (!preg_match('/# HTTP DNS host name.
 			^					   # Anchor to beginning of string.

--- a/include/utf8/utils/bad.php
+++ b/include/utf8/utils/bad.php
@@ -270,7 +270,7 @@ function utf8_bad_identify($str, &$i)
 
 	for($i=0; $i < $len; $i++)
 	{
-		$in = ord($str{$i});
+		$in = ord($str[$i]);
 
 		if ( $mState == 0)
 		{

--- a/include/utf8/utils/validation.php
+++ b/include/utf8/utils/validation.php
@@ -40,7 +40,7 @@ function utf8_is_valid($str)
 
 	for($i = 0; $i < $len; $i++)
 	{
-		$in = ord($str{$i});
+		$in = ord($str[$i]);
 
 		if ( $mState == 0)
 		{


### PR DESCRIPTION
Deprecated syntax `$array{$index}` has been removed in PHP 8 and must be converted to `$array[$index]`. I may have missed some spots here but we can come back for them.