### PR TITLE
Remove deprecated mbstring check

### DIFF
--- a/include/utf8/utf8.php
+++ b/include/utf8/utf8.php
@@ -43,16 +43,6 @@ require UTF8.'/utils/bad.php';
 
 if (defined('UTF8_USE_MBSTRING'))
 {
-	/**
-	* If string overloading is active, it will break many of the
-	* native implementations. mbstring.func_overload must be set
-	* to 0, 1 or 4 in php.ini (string overloading disabled).
-	* Also need to check we have the correct internal mbstring
-	* encoding
-	*/
-	if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING)
-		trigger_error('String functions are overloaded by mbstring', E_USER_ERROR);
-
 	mb_language('uni');
 	mb_internal_encoding('UTF-8');
 


### PR DESCRIPTION
Per: https://www.php.net/manual/en/mbstring.overload.php

mbstring function overloading has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. We no longer need to assert against this feature being enabled.